### PR TITLE
v0.6.0 (#13)

### DIFF
--- a/Streamlink/streamlink.nuspec
+++ b/Streamlink/streamlink.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>streamlink</id>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <packageSourceUrl>https://github.com/streamlink/streamlink-chocolatey</packageSourceUrl>
     <owners>Scott Walters</owners>
     <iconUrl>https://cdn.rawgit.com/streamlink/streamlink/master/win32/doggo.ico</iconUrl>
@@ -24,7 +24,7 @@
 The main purpose of streamlink is to convert CPU-heavy flash plugins to a less CPU-intensive format.
 
 Streamlink is a fork of the [livestreamer](https://github.com/chrippa/livestreamer) project.</description>
-    <releaseNotes>https://github.com/streamlink/streamlink/releases/tag/0.5.0</releaseNotes>
+    <releaseNotes>https://github.com/streamlink/streamlink/releases/tag/0.6.0</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/Streamlink/tools/chocolateyinstall.ps1
+++ b/Streamlink/tools/chocolateyinstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
 
   softwareName  = 'Streamlink*'
 
-  checksum      = '05E9704482CF82F855237F41C2639853D45F065C81B2CDA749CD6CE2C910E479'
+  checksum      = 'b5c7b4e7a9ab7d5b2401604c3a0b1243b449e17f0f9b35a4f7db73d92d009e07'
   checksumType  = 'sha256'
 
   silentArgs   = '/S'


### PR DESCRIPTION
- v0.6.0 of Streamlink
- Updated link to changelog

Attached [.nupkg file](https://github.com/streamlink/streamlink-chocolatey/files/1017635/streamlink.0.6.0.zip) renamed to .zip extension.

### Maintainer's notes
- Resolves #13 
- Pending package approval: https://chocolatey.org/packages/streamlink/0.6.0